### PR TITLE
Appear in private windows as well.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -9,5 +9,8 @@
   "main": "lib/common.js",
   "url": "http://firefox.add0n.com/proxy-switcher.html",
   "icon": "data/icons/32.png",
-  "icon64": "data/icons/64.png"
+  "icon64": "data/icons/64.png",
+  "permissions": {
+    "private-browsing": true
+  }
 }


### PR DESCRIPTION
Note well that these proxy settings are *global* across
all private and non-private windows, simultaneously.